### PR TITLE
Fix SOS timing

### DIFF
--- a/app/src/main/kotlin/com/simplemobiletools/flashlight/helpers/MyCameraImpl.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/flashlight/helpers/MyCameraImpl.kt
@@ -19,7 +19,9 @@ class MyCameraImpl(val context: Context) {
 
     companion object {
         var isFlashlightOn = false
-        private val SOS = arrayListOf(250L, 250L, 250L, 250L, 250L, 250L, 500L, 250L, 500L, 250L, 500L, 250L, 250L, 250L, 250L, 250L, 250L, 1000L)
+
+        private var u = 200L // The length of one dit (Time unit)
+        private val SOS = arrayListOf(u, u, u, u, u, u * 3, u * 3, u, u * 3, u, u * 3, u * 3, u, u, u, u, u, u * 7)
 
         private var camera: Camera? = null
         private var params: Camera.Parameters? = null


### PR DESCRIPTION
Hello, I recently started using this app and really love it. However, the timing on the SOS feature is a little bit off both by the lengths of the flashes and pauses. This PR changes the timing to use the lengths as described [here](https://en.wikipedia.org/wiki/Morse_code#Representation,_timing,_and_speeds). It also changes the unit (Length of a *dit*) to 200 instead of 250.