### PR TITLE
fix(#165): fix flashlight status after coming back from camera app

### DIFF
--- a/app/src/main/kotlin/com/simplemobiletools/flashlight/activities/MainActivity.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/flashlight/activities/MainActivity.kt
@@ -198,6 +198,10 @@ class MainActivity : SimpleActivity() {
                     brightness_bar.beVisibleIf(isEnabled)
                 }
             }
+
+            override fun onTorchUnavailable() {
+                mCameraImpl!!.onCameraNotAvailable()
+            }
         })
         if (config.turnFlashlightOn) {
             mCameraImpl!!.enableFlashlight()
@@ -300,7 +304,7 @@ class MainActivity : SimpleActivity() {
     }
 
     private fun changeIconColor(color: Int, imageView: ImageView?) {
-        imageView!!.background.mutate().applyColorFilter(color)
+        imageView!!.background.applyColorFilter(color)
     }
 
     @SuppressLint("NewApi")

--- a/app/src/main/kotlin/com/simplemobiletools/flashlight/helpers/CameraFlash.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/flashlight/helpers/CameraFlash.kt
@@ -21,6 +21,10 @@ internal class CameraFlash(
         override fun onTorchModeChanged(cameraId: String, enabled: Boolean) {
             cameraTorchListener?.onTorchEnabled(enabled)
         }
+
+        override fun onTorchModeUnavailable(cameraId: String) {
+            cameraTorchListener?.onTorchUnavailable()
+        }
     }
 
     init {

--- a/app/src/main/kotlin/com/simplemobiletools/flashlight/helpers/CameraTorchListener.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/flashlight/helpers/CameraTorchListener.kt
@@ -2,4 +2,6 @@ package com.simplemobiletools.flashlight.helpers
 
 interface CameraTorchListener {
     fun onTorchEnabled(isEnabled:Boolean)
+
+    fun onTorchUnavailable()
 }

--- a/app/src/main/kotlin/com/simplemobiletools/flashlight/helpers/MyCameraImpl.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/flashlight/helpers/MyCameraImpl.kt
@@ -276,4 +276,8 @@ class MyCameraImpl private constructor(val context: Context, private var cameraT
     fun updateBrightnessLevel(level: Int) {
         cameraFlash!!.changeTorchBrightness(level)
     }
+
+    fun onCameraNotAvailable() {
+        disableFlashlight()
+    }
 }


### PR DESCRIPTION
Fix issue #165 

- Add onCameraUnavailable listener to reset flashlight internal state to off